### PR TITLE
Add basic (Free)BSD support.

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -13,7 +13,9 @@ import (
 )
 
 /*
+#cgo LDFLAGS: -lcrypt
 #define _GNU_SOURCE
+#include <stdlib.h>
 #include <unistd.h>
 */
 import "C"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package crypt
 
 /*


### PR DESCRIPTION
This change adds basic BSD support. I have only tested it on FreeBSD for now.

It also disables the build of `LibCVersion()`, because `gnu_get_libc_version()` doesn't exist. Maybe it would make sense to return `sys.GOOS`?