### PR TITLE
Fix check for errors

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -42,6 +42,16 @@ func Crypt(pass, salt string) (string, error) {
 	}
 	defer C.free(unsafe.Pointer(c_enc))
 
+	// From the crypt(3) man-page. Upon error, crypt_r writes an invalid
+	// hashed passphrase to the output field of their data argument, and
+	// crypt writes an invalid hash to its static storage area. This
+	// string will be shorter than 13 characters, will begin with a ‘*’,
+	// and will not compare equal to setting.
+	hash := C.GoString(c_enc)
+	if len(hash) > 0 && hash[0] == '*' {
+		return "", err
+	}
+
 	// Return nil error if the string is non-nil.
 	// As per the errno.h manpage, functions are allowed to set errno
 	// on success. Caller should ignore errno on success.

--- a/crypt_r.go
+++ b/crypt_r.go
@@ -55,8 +55,18 @@ func Crypt(pass, salt string) (string, error) {
 	}
 	defer C.free(unsafe.Pointer(c_enc))
 
+	// From the crypt(3) man-page. Upon error, crypt_r writes an invalid
+	// hashed passphrase to the output field of their data argument, and
+	// crypt writes an invalid hash to its static storage area. This
+	// string will be shorter than 13 characters, will begin with a ‘*’,
+	// and will not compare equal to setting.
+	hash := C.GoString(c_enc)
+	if len(hash) > 0 && hash[0] == '*' {
+		return "", err
+	}
+
 	// Return nil error if the string is non-nil.
 	// As per the errno.h manpage, functions are allowed to set errno
 	// on success. Caller should ignore errno on success.
-	return C.GoString(c_enc), nil
+	return hash, nil
 }


### PR DESCRIPTION
Some implementations of crypt (e.g. libxcrypt as shipped in at least
Fedora and openSUSE) instead of returning NULL on errors might also
return an invalid hash string starting with '*' for indicating an error.
This add some checks for that error condition.

Fixes #8