### PR TITLE
minimal fix for issue-11

### DIFF
--- a/crypt_r.go
+++ b/crypt_r.go
@@ -33,8 +33,7 @@ char *gnu_ext_crypt(char *pass, char *salt) {
   }
 
   ret = (char *)malloc(strlen(enc)+1); // for trailing null
-  strncpy(ret, enc, strlen(enc));
-  ret[strlen(enc)]= '\0'; // paranoid
+  strcpy(ret, enc);
 
   return ret;
 }


### PR DESCRIPTION
Since there is no bounds checking on the `strlen(enc)` there's no point in using `strncpy`.  Therefore, the minimal fix is to simply use `strcpy`.  This has been tested and works as expected. 
